### PR TITLE
MISP-2397 Fix skipped unit tests in test classes

### DIFF
--- a/cfg/pytest.ini
+++ b/cfg/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = ./tests
 python_files = test*.py
-python_classes = *Test
+python_classes = *Test Test*
 log_cli = False
 log_cli_level = WARNING


### PR DESCRIPTION
Projects such as opinicus have legacy testing code that defines test classes with names following the pattern `Test*`. However, our current pytest configuration only defines the naming pattern `*Test`, causing a lot of existing tests in opinicus to be skipped.

Add the currently-used naming pattern to our pytest config, so that these legacy tests are included again.

(Note: we do *not* need to also include the `*TestCase` naming pattern for legacy tests based on Python's `unittest` framework, as pytest already picks up on *all* child classes derived from `unittest.TestCase`.)

**Edit**: This change "wakes up" 39 "sleeping" tests in _opinicus_. All of those still pass on my machine, so I don't expect us to need additional work to fix silently broken tests.