### PR TITLE
MISP-2449 Update the default branch name to master/s-line

### DIFF
--- a/references.sh
+++ b/references.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-PARENT_BRANCH=${PARENT_BRANCH:-master}
+PARENT_BRANCH=${PARENT_BRANCH:-master/s-line}
 CHANGED_BRANCH_FILES=$(git diff --name-only --diff-filter=d origin/"${PARENT_BRANCH}"...HEAD :^tests | grep -i .py$ | cat )
 
 if [ -z "${ONLY_CHECK_STAGED:=""}" ] ; then


### PR DESCRIPTION
When running references.sh, the default branch name should now be master/s-line instead of just master, to keep this in line with the changes being made with MISP-2347