### PR TITLE
CES-2401: Update the default branch name to 'main'

### DIFF
--- a/references.sh
+++ b/references.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-PARENT_BRANCH=${PARENT_BRANCH:-master/s-line}
+PARENT_BRANCH=${PARENT_BRANCH:-main}
 CHANGED_BRANCH_FILES=$(git diff --name-only --diff-filter=d origin/"${PARENT_BRANCH}"...HEAD :^tests | grep -i .py$ | cat )
 
 if [ -z "${ONLY_CHECK_STAGED:=""}" ] ; then


### PR DESCRIPTION
When running references.sh, the default branch name should now be `main` instead of `master/s-line`, to keep this in line with the changes made in SEM-209 (The unforking of Colorado and S-Line code bases)