### PR TITLE
[CES-2407] Exclude venv from vulture

### DIFF
--- a/run_vulture.sh
+++ b/run_vulture.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-vulture --min-confidence 95 --exclude tests/,.git/ ./
+vulture --min-confidence 95 --exclude tests/,.git/,venv/ ./
 
 exit 0


### PR DESCRIPTION
like title says. When you create a virtual environment in PyCharm (as many might do), the vulture check will also check the venv folder, failing on Python modules that aren't our own dev code. You want to prevent this, so similar to the test folder, I excluded any potential venv folder.

Tested by running the vulture script and it will successfully pass and return 0 as error code with this change.