### PR TITLE
[CES-2530] Add MqttHandler to clone action

### DIFF
--- a/.github/actions/fetch_companion_repos/action.yml
+++ b/.github/actions/fetch_companion_repos/action.yml
@@ -63,4 +63,11 @@ runs:
           token: ${{ inputs.token }}
           repository: ultiLib
           default-branch: ${{ inputs.default-branch }}
+
+      - name: Clone mqttHandler
+        uses: Ultimaker/python-quality-control/.github/actions/clone_repo@master
+        with:
+          token: ${{ inputs.token }}
+          repository: mqttHandler
+          default-branch: ${{ inputs.default-branch }}
           


### PR DESCRIPTION
New MqttHandler needs to be added to the clone action for pytest, otherwise it cannot be used.