### PR TITLE
vulture: Ignore `tools/` subdirectory

### DIFF
--- a/run_vulture.sh
+++ b/run_vulture.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-vulture --min-confidence 95 --exclude tests/,.git/,venv/ ./
+vulture --min-confidence 95 --exclude tests/,.git/,venv/,tools/ ./
 
 exit 0


### PR DESCRIPTION
Ignore the `tools/` subdirectory when doing `vulture` checks.  For supporting Ultimaker/print-process-reporting#34