### PR TITLE
[CES-2925] Allow repo specific files to be excluded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ Actions:
 - **clone_repo**: Clone a specific repository and try to check out the current working branch, otherwise checkout the default one (default can be specified using an input field. If not specified, it uses the repo default one).
 
 - **fetch_companion_repos**: Clone all “known” companion repos (currently: dbus-interface-lib, marvin-service, libPalantir, libSmeagol, libCharon, libLogger, ultiLib). This action basically calls clone_repo for all those repositories.
+
+
+Excluding files:
+
+Files can be excluded from the linting by individual repositories using a text file in the root of the repo with the name: linting_excluded_file.txt.
+The format for the file expected would be:
+```
+cfg/flake8.ini
+references.sh
+```

--- a/references.sh
+++ b/references.sh
@@ -3,6 +3,7 @@ set -eu
 
 PARENT_BRANCH=${PARENT_BRANCH:-main}
 CHANGED_BRANCH_FILES=$(git diff --name-only --diff-filter=d origin/"${PARENT_BRANCH}"...HEAD :^tests | grep -i .py$ | cat )
+EXCLUDE_FILE_NAME="linting_excluded_files.txt"
 
 if [ -z "${ONLY_CHECK_STAGED:=""}" ] ; then
     echo "Local + staged + branch changes"
@@ -15,8 +16,8 @@ fi
 CHANGED_FILES=$(echo "${CHANGED_BRANCH_FILES}" "${CHANGED_LOCAL_FILES}" | tr ' ' '\n' | sort | uniq)
 
 # Remove excluded files from changed files
-if [ -f "excluded_files.txt" ]; then
-    EXCLUDED_FILES=$(cat "excluded_files.txt")
+if [ -f "${EXCLUDE_FILE_NAME}" ]; then
+    EXCLUDED_FILES=$(cat "${EXCLUDE_FILE_NAME}")
     CHANGED_FILES=$(echo "${CHANGED_FILES}" | grep -vF "${EXCLUDED_FILES}")
 fi
 


### PR DESCRIPTION
## Description
Allow repo's to specifically exclude files, by looking for an `linting_excluded_files` file in the root of the repo. 

## How was this tested
I changed some lines in the file that is part of the excluded files file. When I ran the references script it was not in the list of changed files.
When there is no excluded_files file the script works fine