### PR TITLE
[SEM-526] Recognize libCharon test file pattern

### DIFF
--- a/cfg/pytest.ini
+++ b/cfg/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = ./tests
-python_files = test*.py
+python_files = [Tt]est*.py
 python_classes = *Test Test*
 log_cli = False
 log_cli_level = WARNING


### PR DESCRIPTION
# [SEM-526] Recognize libCharon test file pattern

This change was needed to get the libCharon CI running, as the unittest files there start with a capital T.

[SEM-526]: https://ultimaker.atlassian.net/browse/SEM-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ