### PR TITLE
[CES-3227] CI fixups

### DIFF
--- a/cfg/pycodestyle.ini
+++ b/cfg/pycodestyle.ini
@@ -5,5 +5,7 @@ ignore = E722,
     ; Too many leading '#' for block comment
     E266,
     ; Line too long
-    E501
+    E501,
+    ; Multiple spaces after comma
+    E241
 max-line-length = 120

--- a/references.sh
+++ b/references.sh
@@ -17,8 +17,7 @@ CHANGED_FILES=$(echo "${CHANGED_BRANCH_FILES}" "${CHANGED_LOCAL_FILES}" | tr ' '
 
 # Remove excluded files from changed files
 if [ -f "${EXCLUDE_FILE_NAME}" ]; then
-    EXCLUDED_FILES=$(cat "${EXCLUDE_FILE_NAME}")
-    CHANGED_FILES=$(echo "${CHANGED_FILES}" | grep -vF "${EXCLUDED_FILES}")
+    CHANGED_FILES=$(echo "${CHANGED_FILES}" | grep -v -f "${EXCLUDE_FILE_NAME}")
 fi
 
 export PARENT_BRANCH


### PR DESCRIPTION
This concerns a CES-3226 regex boyscout for the linting ignore files. It has been reviewed but since I did not update the CI commit hash yet, it is included here.

The CES-3227 commit concerns a fix to the pycodestyle.ini to ignore E241 whitespace after , error. This was enabled by passing an ignore list to pycodestyle; noqa is not implemented, this is the only solution.