### PR TITLE
[boyscout] Update mypy so Opinicus checks work again

### DIFF
--- a/cfg/ci_requirements.txt
+++ b/cfg/ci_requirements.txt
@@ -1,7 +1,7 @@
 flake8==4.0.1
 flake8-polyfill==1.0.2
 flake8-quotes==3.3.1
-mypy==0.910
+mypy==1.5.1
 pyfakefs==4.5.6
 pycodestyle==2.8.0
 pytest==6.2.5


### PR DESCRIPTION
After updating to bookworm for our CI pipeline, MyPy fails with the rather cryptic error:
```
/opt/venv/lib/python3.11/site-packages/numpy/__init__.pyi:640: error: Positional-only parameters are only supported in Python 3.8 and greater
```

This has to do with mypy 0.910 not supporting positional parameters well. This updates mypy to 1.5.1 which does support that.

This is a fixup for SEM-6756.